### PR TITLE
[c#/beetlex] change Server: TFB, change custom connection pool, add u…

### DIFF
--- a/frameworks/CSharp/beetlex/Benchmarks/DBRaw.cs
+++ b/frameworks/CSharp/beetlex/Benchmarks/DBRaw.cs
@@ -16,14 +16,12 @@ namespace Benchmarks
 
         private readonly DbProviderFactory _dbProviderFactory;
 
-        private readonly string _connectionString;
+        public static string _connectionString;
 
         public RawDb(ConcurrentRandom random, DbProviderFactory dbProviderFactory)
         {
             _random = random;
             _dbProviderFactory = dbProviderFactory;
-            _connectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
-           // _connectionString = "Server=192.168.2.19;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
             OnCreateCommand();
         }
 

--- a/frameworks/CSharp/beetlex/Benchmarks/Program.cs
+++ b/frameworks/CSharp/beetlex/Benchmarks/Program.cs
@@ -63,7 +63,7 @@ namespace Benchmarks
         public async Task<object> updates(int queries, IHttpContext context)
         {
             queries = queries < 1 ? 1 : queries > 500 ? 500 : queries;
-            var result= await GetDB(context).LoadMultipleUpdatesRows(queries);
+            var result = await GetDB(context).LoadMultipleUpdatesRows(queries);
             return new SpanJsonResult(result);
         }
 
@@ -97,11 +97,14 @@ namespace Benchmarks
             mApiServer.Options.LogToConsole = true;
             mApiServer.Options.PrivateBufferPool = true;
             mApiServer.Register(typeof(Program).Assembly);
+            HeaderTypeFactory.SERVAR_HEADER_BYTES = Encoding.ASCII.GetBytes("Server: TFB\r\n");
             mApiServer.HttpConnected += (o, e) =>
             {
                 e.Session["DB"] = new RawDb(new ConcurrentRandom(), Npgsql.NpgsqlFactory.Instance);
             };
             mApiServer.Open();
+            RawDb._connectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
+            //RawDb._connectionString = "Server=192.168.2.19;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
             System.Net.Http.HttpClient client = new System.Net.Http.HttpClient();
             var response = await client.GetAsync("http://localhost:8080/json");
             mApiServer.BaseServer.Log(LogType.Info, null, $"Get josn {response.StatusCode}");

--- a/frameworks/CSharp/beetlex/PlatformBenchmarks/DBRaw.cs
+++ b/frameworks/CSharp/beetlex/PlatformBenchmarks/DBRaw.cs
@@ -1,10 +1,14 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using System.Data;
 using System.Data.Common;
 using System.Linq;
+using System.Runtime.Versioning;
 using System.Text;
 using System.Threading.Tasks;
+using System.Runtime.InteropServices.ComTypes;
+using BeetleX.EventArgs;
 
 namespace PlatformBenchmarks
 {
@@ -15,17 +19,14 @@ namespace PlatformBenchmarks
 
         private readonly DbProviderFactory _dbProviderFactory;
 
-        private readonly string _connectionString;
+        public static string _connectionString = null;
 
         public RawDb(ConcurrentRandom random, DbProviderFactory dbProviderFactory)
         {
             _random = random;
             _dbProviderFactory = dbProviderFactory;
-            _connectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
-           // _connectionString = "Server=192.168.2.19;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
             OnCreateCommand();
         }
-
         private void OnCreateCommand()
         {
             SingleCommand = new Npgsql.NpgsqlCommand();
@@ -36,7 +37,7 @@ namespace PlatformBenchmarks
             id.Value = _random.Next(1, 10001);
             SingleCommand.Parameters.Add(id);
             FortuneCommand = new Npgsql.NpgsqlCommand();
-            FortuneCommand.CommandText= "SELECT id, message FROM fortune";
+            FortuneCommand.CommandText = "SELECT id, message FROM fortune";
         }
 
         private DbCommand SingleCommand;
@@ -45,13 +46,11 @@ namespace PlatformBenchmarks
 
         public async Task<World> LoadSingleQueryRow()
         {
-            using (var db = _dbProviderFactory.CreateConnection())
+            using (var db = await DBConnectionGroupPool.Pop())
             {
-                db.ConnectionString = _connectionString;
-                await db.OpenAsync();
-                SingleCommand.Connection = db;
+                SingleCommand.Connection = db.Connection;
                 SingleCommand.Parameters[0].Value = _random.Next(1, 10001);
-                return await ReadSingleRow(db, SingleCommand);
+                return await ReadSingleRow(db.Connection, SingleCommand);
 
             }
         }
@@ -59,9 +58,9 @@ namespace PlatformBenchmarks
         async Task<World> ReadSingleRow(DbConnection connection, DbCommand cmd)
         {
             using (var rdr = await cmd.ExecuteReaderAsync(CommandBehavior.SingleRow))
+
             {
                 await rdr.ReadAsync();
-
                 return new World
                 {
                     Id = rdr.GetInt32(0),
@@ -72,11 +71,9 @@ namespace PlatformBenchmarks
 
         public async Task<World[]> LoadMultipleQueriesRows(int count)
         {
-            using (var db = _dbProviderFactory.CreateConnection())
+            using (var db = await DBConnectionGroupPool.Pop())
             {
-                db.ConnectionString = _connectionString;
-                await db.OpenAsync();
-                return await LoadMultipleRows(count, db);
+                return await LoadMultipleRows(count, db.Connection);
             }
 
         }
@@ -99,13 +96,10 @@ namespace PlatformBenchmarks
         {
             var result = new List<Fortune>();
 
-            using (var db = _dbProviderFactory.CreateConnection())
-
-            { 
-                db.ConnectionString = _connectionString;
-                await db.OpenAsync();
-                FortuneCommand.Connection = db;
-                using (var rdr = await FortuneCommand.ExecuteReaderAsync(CommandBehavior.CloseConnection))
+            using (var db = await DBConnectionGroupPool.Pop())
+            {
+                FortuneCommand.Connection = db.Connection;
+                using (var rdr = await FortuneCommand.ExecuteReaderAsync(CommandBehavior.Default))
                 {
                     while (await rdr.ReadAsync())
                     {
@@ -123,59 +117,120 @@ namespace PlatformBenchmarks
         }
         public async Task<World[]> LoadMultipleUpdatesRows(int count)
         {
-            using (var db = _dbProviderFactory.CreateConnection())
+            using (var db = await DBConnectionGroupPool.Pop())
             {
-                db.ConnectionString = _connectionString;
-                await db.OpenAsync();
-
-                using (var updateCmd = db.CreateCommand())
-                using (var queryCmd = CreateReadCommand(db))
+                var updateCmd = UpdateCommandsCached.PopCommand(count);
+                try
                 {
+                    updateCmd.Connection = db.Connection;
+                    SingleCommand.Connection = db.Connection;
+                    SingleCommand.Parameters[0].Value = _random.Next(1, int.MaxValue) % 10000 + 1;
                     var results = new World[count];
                     for (int i = 0; i < count; i++)
                     {
-                        results[i] = await ReadSingleRow(db, queryCmd);
-                        queryCmd.Parameters["@Id"].Value = _random.Next(1, 10001);
+                        results[i] = await ReadSingleRow(db.Connection, SingleCommand);
+                        SingleCommand.Parameters[0].Value = _random.Next(1, int.MaxValue) % 10000 + 1;
                     }
-
-                    updateCmd.CommandText = BatchUpdateString.Query(count);
 
                     for (int i = 0; i < count; i++)
                     {
-                        var id = updateCmd.CreateParameter();
-                        id.ParameterName = $"@Id_{i}";
-                        id.DbType = DbType.Int32;
-                        updateCmd.Parameters.Add(id);
-
-                        var random = updateCmd.CreateParameter();
-                        random.ParameterName = $"@Random_{i}";
-                        random.DbType = DbType.Int32;
-                        updateCmd.Parameters.Add(random);
-
-                        var randomNumber = _random.Next(1, 10001);
-                        id.Value = results[i].Id;
-                        random.Value = randomNumber;
+                        var randomNumber = _random.Next(1, int.MaxValue) % 10000 + 1;
+                        updateCmd.Parameters[i * 2].Value = results[i].Id;
+                        updateCmd.Parameters[i * 2 + 1].Value = randomNumber;
                         results[i].RandomNumber = randomNumber;
                     }
 
                     await updateCmd.ExecuteNonQueryAsync();
                     return results;
                 }
+                catch (Exception e_)
+                {
+                    throw e_;
+                }
+                finally
+                {
+                    UpdateCommandsCached.PushCommand(count, updateCmd);
+                }
+            }
+        }
+    }
+
+    internal class UpdateCommandsCached
+    {
+        private static System.Collections.Concurrent.ConcurrentStack<DbCommand>[] mCacheTable
+            = new System.Collections.Concurrent.ConcurrentStack<DbCommand>[1024];
+
+        public static string[] IDParamereNames = new string[1024];
+
+        public static string[] RandomParamereNames = new string[1024];
+
+        static UpdateCommandsCached()
+        {
+            for (int i = 0; i < 1024; i++)
+            {
+                IDParamereNames[i] = $"@Id_{i}";
+                RandomParamereNames[i] = $"@Random_{i}";
+                mCacheTable[i] = new System.Collections.Concurrent.ConcurrentStack<DbCommand>();
             }
         }
 
-        DbCommand CreateReadCommand(DbConnection connection)
+        private static DbCommand CreatCommand(int count)
         {
-            var cmd = connection.CreateCommand();
-            cmd.CommandText = "SELECT id, randomnumber FROM world WHERE id = @Id";
-            var id = cmd.CreateParameter();
-            id.ParameterName = "@Id";
-            id.DbType = DbType.Int32;
-            id.Value = _random.Next(1, 10001);
-            cmd.Parameters.Add(id);
+            DbCommand cmd = new Npgsql.NpgsqlCommand();
+            cmd.CommandText = BatchUpdateString.Query(count);
+            for (int i = 0; i < count; i++)
+            {
+                var id = cmd.CreateParameter();
+                id.ParameterName = IDParamereNames[i];
+                id.DbType = DbType.Int32;
+                cmd.Parameters.Add(id);
+
+                var random = cmd.CreateParameter();
+                random.ParameterName = RandomParamereNames[i];
+                random.DbType = DbType.Int32;
+                cmd.Parameters.Add(random);
+            }
             return cmd;
+
+        }
+
+        public static void PushCommand(int count, DbCommand cmd)
+        {
+            mCacheTable[count].Push(cmd);
+        }
+
+        public static DbCommand PopCommand(int count)
+        {
+            if (mCacheTable[count].TryPop(out DbCommand cmd))
+                return cmd;
+            return CreatCommand(count);
+        }
+
+        private static bool mInited = false;
+
+        public static void Init()
+        {
+            if (mInited)
+                return;
+            lock (typeof(UpdateCommandsCached))
+            {
+                if (mInited)
+                    return;
+                for (int i = 1; i <= 500; i++)
+                {
+                    for (int k = 0; k < 10; k++)
+                    {
+                        var cmd = CreatCommand(i);
+                        mCacheTable[i].Push(cmd);
+                    }
+                }
+                mInited = true;
+                HttpServer.ApiServer.Log(LogType.Info, null, $"Init update commands cached");
+                return;
+            }
         }
     }
+
 
     internal class BatchUpdateString
     {
@@ -249,4 +304,112 @@ namespace PlatformBenchmarks
             return result;
         }
     }
+
+    internal class DBConnectionGroupPool
+    {
+        private static long mIndex;
+
+        private static List<DBconnectionPool> mPools = new List<DBconnectionPool>();
+
+        private static bool mInited = false;
+
+        public static void Init(int max, string connectionstring)
+        {
+            if (mInited)
+                return;
+            lock (typeof(DBconnectionPool))
+            {
+                if (mInited)
+                    return;
+                int group = 2;
+                if (!Program.UpDB)
+                    group = 16;
+                else
+                    group = 4;
+                HttpServer.ApiServer.Log(BeetleX.EventArgs.LogType.Info, null, $"connection pool init {max} group {group}");
+                int itemcount = (max / group);
+                for (int i = 0; i < group; i++)
+                {
+                    DBconnectionPool pool = new DBconnectionPool();
+                    pool.Init(itemcount, connectionstring);
+                    mPools.Add(pool);
+                }
+                HttpServer.ApiServer.Log(LogType.Info, null, $"Init connection pool completed");
+                mInited = true;
+                return;
+            }
+        }
+
+        public static Task<DBConnectionItem> Pop()
+        {
+            long id = System.Threading.Interlocked.Increment(ref mIndex);
+            return mPools[(int)(id % mPools.Count)].Pop();
+        }
+
+        public class DBconnectionPool
+        {
+
+            private Stack<DBConnectionItem> mConnectionPool = new Stack<DBConnectionItem>();
+
+            private Queue<TaskCompletionSource<DBConnectionItem>> mWaitQueue = new Queue<TaskCompletionSource<DBConnectionItem>>();
+
+            public void Init(int count, string connectionString)
+            {
+                for (int i = 0; i < count; i++)
+                {
+                    DbConnection connection = Npgsql.NpgsqlFactory.Instance.CreateConnection();
+                    connection.ConnectionString = connectionString;
+                    connection.Open();
+                    DBConnectionItem item = new DBConnectionItem();
+                    item.Pool = this;
+                    item.Connection = connection;
+                    mConnectionPool.Push(item);
+                }
+            }
+
+
+            public Task<DBConnectionItem> Pop()
+            {
+                lock (this)
+                {
+                    if (mConnectionPool.Count > 0)
+                        return Task.FromResult(mConnectionPool.Pop());
+                    TaskCompletionSource<DBConnectionItem> result = new TaskCompletionSource<DBConnectionItem>();
+                    mWaitQueue.Enqueue(result);
+                    return result.Task;
+                }
+            }
+            public void Push(DBConnectionItem item)
+            {
+                TaskCompletionSource<DBConnectionItem> work = null;
+                lock (this)
+                {
+                    if (mWaitQueue.Count > 0)
+                        work = mWaitQueue.Dequeue();
+                    else
+                        mConnectionPool.Push(item);
+                }
+                if (work != null)
+                {
+                    Task.Run(() => work.SetResult(item));
+                }
+            }
+
+        }
+
+        public class DBConnectionItem : IDisposable
+        {
+            public DBconnectionPool Pool { get; set; }
+
+            public DbConnection Connection { get; set; }
+
+            public void Dispose()
+            {
+                Pool.Push(this);
+            }
+        }
+
+
+    }
+
 }

--- a/frameworks/CSharp/beetlex/PlatformBenchmarks/HttpHandler.cs
+++ b/frameworks/CSharp/beetlex/PlatformBenchmarks/HttpHandler.cs
@@ -17,7 +17,7 @@ namespace PlatformBenchmarks
 
         private static AsciiString _httpsuccess = new AsciiString("HTTP/1.1 200 OK\r\n");
 
-        private static readonly AsciiString _headerServer = "Server: Beetlex\r\n";
+        private static readonly AsciiString _headerServer = "Server: TFB\r\n";
 
         private static readonly AsciiString _headerContentLength = "Content-Length: ";
 
@@ -53,7 +53,7 @@ namespace PlatformBenchmarks
         {
             int threads = System.Math.Min(Environment.ProcessorCount, 16);
             NextQueueGroup = new NextQueueGroup(threads);
-          
+
         }
 
         public void Default(ReadOnlySpan<byte> url, PipeStream stream, HttpToken token, ISession session)
@@ -88,7 +88,7 @@ namespace PlatformBenchmarks
         {
             public void Dispose()
             {
-               
+
             }
 
             public PipeStream Stream { get; set; }
@@ -106,19 +106,19 @@ namespace PlatformBenchmarks
             }
         }
 
-        private void OnProcess(PipeStream pipeStream,HttpToken token,ISession sessino)
+        private void OnProcess(PipeStream pipeStream, HttpToken token, ISession sessino)
         {
             var line = _line.AsSpan();
             int len = (int)pipeStream.FirstBuffer.Length;
-            var receiveData = pipeStream.FirstBuffer.Memory.Span;      
-            ReadOnlySpan<byte> http= line;
-            ReadOnlySpan<byte> method= line;
-            ReadOnlySpan<byte> url= line;
+            var receiveData = pipeStream.FirstBuffer.Memory.Span;
+            ReadOnlySpan<byte> http = line;
+            ReadOnlySpan<byte> method = line;
+            ReadOnlySpan<byte> url = line;
             int offset2 = 0;
             int count = 0;
-            for(int i=0;i<len;i++)
+            for (int i = 0; i < len; i++)
             {
-                if(receiveData[i]==line[0])
+                if (receiveData[i] == line[0])
                 {
                     http = receiveData.Slice(offset2, i - offset2);
                     break;
@@ -169,6 +169,14 @@ namespace PlatformBenchmarks
 
         public virtual void OnStartLine(ReadOnlySpan<byte> http, ReadOnlySpan<byte> method, ReadOnlySpan<byte> url, ISession session, HttpToken token, PipeStream stream)
         {
+            if (!Program.Debug)
+            {
+                UpdateCommandsCached.Init();
+                if (Program.UpDB)
+                    DBConnectionGroupPool.Init(32, RawDb._connectionString);
+                else
+                    DBConnectionGroupPool.Init(256, RawDb._connectionString);
+            }
             int queryIndex = AnalysisUrl(url);
             ReadOnlySpan<byte> baseUrl = default;
             ReadOnlySpan<byte> queryString = default;

--- a/frameworks/CSharp/beetlex/PlatformBenchmarks/HttpServer.cs
+++ b/frameworks/CSharp/beetlex/PlatformBenchmarks/HttpServer.cs
@@ -11,31 +11,38 @@ namespace PlatformBenchmarks
 {
     public class HttpServer : IHostedService
     {
-        private IServer mApiServer;
+        public static IServer ApiServer;
 
-        public virtual async Task StartAsync(CancellationToken cancellationToken)
+        public virtual Task StartAsync(CancellationToken cancellationToken)
         {
             ArraySegment<byte> date = GMTDate.Default.DATE;
             ServerOptions serverOptions = new ServerOptions();
             serverOptions.LogLevel = LogType.Error;
             serverOptions.DefaultListen.Port = 8080;
             serverOptions.Statistical = false;
-            serverOptions.BufferSize = 2048;
+            serverOptions.BufferSize = 1024 * 8;
             serverOptions.BufferPoolMaxMemory = 1000;
-            serverOptions.BufferPoolSize = 1024 * 4;
-            mApiServer = SocketFactory.CreateTcpServer<HttpHandler>(serverOptions);
-            mApiServer.Open();
-            System.Net.Http.HttpClient client = new System.Net.Http.HttpClient();
-            var response = await client.GetAsync("http://localhost:8080/json");
-            mApiServer.Log(LogType.Info, null, $"Get josn {response.StatusCode}");
-            response = await client.GetAsync("http://localhost:8080/plaintext");
-            mApiServer.Log(LogType.Info, null, $"Get plaintext {response.StatusCode}");
-            mApiServer.Log(LogType.Info, null, $"Debug mode [{Program.Debug}]");
+            serverOptions.BufferPoolSize = 1024 * 8;
+            ApiServer = SocketFactory.CreateTcpServer<HttpHandler>(serverOptions);
+            ApiServer.Open();
+            if (!Program.UpDB)
+            {
+                RawDb._connectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
+               // RawDb._connectionString = "Server=192.168.2.19;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=256;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
+            }
+            else
+            {
+                // RawDb._connectionString = "Server=192.168.2.19;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=32;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
+                RawDb._connectionString = "Server=tfb-database;Database=hello_world;User Id=benchmarkdbuser;Password=benchmarkdbpass;Maximum Pool Size=32;NoResetOnClose=true;Enlist=false;Max Auto Prepare=3";
+            }           
+            ApiServer.Log(LogType.Info, null, $"Debug mode [{Program.Debug}]");
+            return Task.CompletedTask;
+
         }
 
         public virtual Task StopAsync(CancellationToken cancellationToken)
         {
-            mApiServer.Dispose();
+            ApiServer.Dispose();
             return Task.CompletedTask;
         }
     }

--- a/frameworks/CSharp/beetlex/PlatformBenchmarks/Program.cs
+++ b/frameworks/CSharp/beetlex/PlatformBenchmarks/Program.cs
@@ -9,9 +9,12 @@ namespace PlatformBenchmarks
 
         public static bool Debug = false;
 
+        public static bool UpDB = false;
+
         public static void Main(string[] args)
         {
             Debug = (args != null && args.Length > 0 && args[0] == "debug");
+            UpDB = (args != null && args.Length > 0 && args[0] == "updb");
             new HostBuilder().ConfigureServices(delegate (HostBuilderContext hostContext, IServiceCollection services)
             {
                 services.AddHostedService<HttpServer>();

--- a/frameworks/CSharp/beetlex/PlatformBenchmarks/db.cs
+++ b/frameworks/CSharp/beetlex/PlatformBenchmarks/db.cs
@@ -19,6 +19,7 @@ namespace PlatformBenchmarks
             }
             catch(Exception e_)
             {
+                HttpServer.ApiServer.Log(BeetleX.EventArgs.LogType.Error, null, $"db error {e_.Message}@{e_.StackTrace}");
                 stream.Write(e_.Message);
             }
             OnCompleted(stream, session, token);

--- a/frameworks/CSharp/beetlex/PlatformBenchmarks/fortunes.cs
+++ b/frameworks/CSharp/beetlex/PlatformBenchmarks/fortunes.cs
@@ -34,6 +34,7 @@ namespace PlatformBenchmarks
             }
             catch (Exception e_)
             {
+                HttpServer.ApiServer.Log(BeetleX.EventArgs.LogType.Error, null, $"fortunes error {e_.Message}@{e_.StackTrace}");
                 stream.Write(e_.Message);
             }
             OnCompleted(stream, session, token);

--- a/frameworks/CSharp/beetlex/PlatformBenchmarks/updates.cs
+++ b/frameworks/CSharp/beetlex/PlatformBenchmarks/updates.cs
@@ -34,6 +34,7 @@ namespace PlatformBenchmarks
             }
             catch (Exception e_)
             {
+                HttpServer.ApiServer.Log(BeetleX.EventArgs.LogType.Error, null, $"updates error {e_.Message}@{e_.StackTrace}");
                 stream.Write(e_.Message);
             }
             OnCompleted(stream, session, token);

--- a/frameworks/CSharp/beetlex/beetlex-core-updb.dockerfile
+++ b/frameworks/CSharp/beetlex/beetlex-core-updb.dockerfile
@@ -1,0 +1,9 @@
+FROM mcr.microsoft.com/dotnet/core/sdk:3.1.101 AS build
+WORKDIR /app
+COPY PlatformBenchmarks .
+RUN dotnet publish -c Release -o out
+
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1.2 AS runtime
+WORKDIR /app
+COPY --from=build /app/out ./
+ENTRYPOINT ["dotnet", "PlatformBenchmarks.dll","updb"]

--- a/frameworks/CSharp/beetlex/benchmark_config.json
+++ b/frameworks/CSharp/beetlex/benchmark_config.json
@@ -48,6 +48,24 @@
         "notes": "",
         "versus": "aspcore"
       },
+      "core-updb": {
+        "update_url": "/updates?queries=",
+        "port": 8080,
+        "approach": "Realistic",
+        "classification": "Platform",
+        "database": "Postgres",
+        "framework": "beetlex",
+        "language": "C#",
+        "orm": "Raw",
+        "platform": ".NET",
+        "flavor": "CoreCLR",
+        "webserver": "beetlex",
+        "os": "Linux",
+        "database_os": "Linux",
+        "display_name": "beetlex-core",
+        "notes": "",
+        "versus": "aspcore"
+      },
       "debug": {
         "plaintext_url": "/plaintext",
         "json_url": "/json",


### PR DESCRIPTION
…pdate docker (#5769)

* update beetlex 1.4.3

update beetlex 1.4.3

* docker add COMPlus_ReadyToRun variable
update beetlex

* update beetlex, enabled thread queue

* beetlex framework add db and queries cases

* add db code

* change result json data

* update query url

* beetlex framework add fortunes cases

* change Content-Type

* add beetlex core cases

* fix queries cases

* update config

* change try readline

* update benchmark config

* Update README.md

* Update README.md

* change versus property

* beetlex-core update .net core to v3.0

* change beetlex-core project file

* beetlex update raw db class

* beetlex update raw db

* beetlex debug plaintext

* change debug docker file

* update beetlex to 1.4.0

* update

* beetlex update core 3.1

* [c#/beetlex] add updates cases

* [c#/beetlex] change Server: TFB, change custom connection pool, add update docker

* fix errors

* change pool init

* change connection pool maxsize

* fix fortunes errors

* clear DBRaw _connectionString value.

<!--
Thank you for submitting to the TechEmpower Framework Benchmarks!

If you are submitting a new framework, please make sure that you add the appropriate line in the `.travis.yml` file for proper integration testing. Also please make sure that an appropriate `README.md` is added in your framework directory with information about the framework and a link to its homepage and documentation.

For new frameworks, please do not include source code that isn't required for the benchmarks.

Some examples of files that should not be included:

* Functional tests, such as JUnit tests in a `src/test` directory in Java frameworks.
* Startup scripts for launching the framework's application directly without going through TFB.
* Local development configs used on the developer's workstation but not in TFB.

If you are editing an existing test, please update the `README.md` for that test where appropriate.
-->
